### PR TITLE
Fix mouse hovers and transforms

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -190,7 +190,7 @@ void Application::render() {
   // an excessive number of mouse move events which incurs a performance hit.
   if(pickDrawCountdown < 0) {
     Vector2D p(mouseX, screenH - mouseY);
-    scene->getHoveredObject(p); 
+    scene->getHoveredObject(p);
     pickDrawCountdown += pickDrawInterval;
   } else {
     pickDrawCountdown--;
@@ -254,7 +254,7 @@ void Application::render() {
             DynamicScene::Skeleton *skel = j->skeleton;
             if (ikTargets.find(j) != ikTargets.end()) {
               ikTargets.erase(j);
-            } 
+            }
             double dist = (j->getEndPosInWorld() - camera.position()).norm();
             ikTargets.emplace(j, getMouseProjection(dist));
             skel->reachForTarget(ikTargets, timeline.getCurrentFrame());
@@ -496,8 +496,6 @@ void Application::cursor_event(float x, float y) {
     mouse1_dragged(x, y);
   } else if (!leftDown && !middleDown && rightDown) {
     mouse2_dragged(x, y);
-  } else if (!leftDown && !middleDown && !rightDown) {
-    mouse_moved(x, y);
   }
 
   mouseX = x;
@@ -1499,23 +1497,6 @@ void Application::mouse2_dragged(float x, float y) {
   updateWidgets();
 }
 
-void Application::mouse_moved(float x, float y) {
-  y = screenH - y;  // Because up is down.
-                    // Converts x from [0, w] to [-1, 1], and similarly for y.
-  // Vector2D p(x * 2 / screenW - 1, y * 2 / screenH - 1);
-  Vector2D p(x, y);
-  update_gl_camera();
-  if (mode == MODEL_MODE) {
-    // scene->getHoveredObject(p); // Nick: This kills performance on some platforms which generate A LOT of mouse_moved events.
-  } else if (mode == ANIMATE_MODE) {
-    if (action == Action::Wave) {
-      scene->getHoveredObject(p, true, true);
-    } else {
-      scene->getHoveredObject(p, false, true);
-    }
-  }
-}
-
 void Application::switch_modes(unsigned int key) {
   switch (key) {
     case 'a':
@@ -1551,7 +1532,6 @@ void Application::to_model_mode() {
   }
 
   action = Action::Navigate;
-  mouse_moved(mouseX, mouseY);
   setGhosted(false);
 }
 

--- a/src/application.h
+++ b/src/application.h
@@ -228,7 +228,6 @@ class Application : public Renderer {
   void mouse_released(e_mouse_button b);  // Mouse Released.
   void mouse1_dragged(float x, float y);  // Left Mouse Dragged.
   void mouse2_dragged(float x, float y);  // Right Mouse Dragged.
-  void mouse_moved(float x, float y);     // Mouse Moved.
 
   /**
    * If there is current selection and it's draggable, apply its drag method.

--- a/src/dynamic_scene/scene.h
+++ b/src/dynamic_scene/scene.h
@@ -105,7 +105,7 @@ class SceneObject {
    * will be used by Scene::getHoveredObject to make the final determination
    * of which object (and possibly element within that object) was picked.
    */
-  virtual void draw_pick(int &pickID, bool transformed = false) = 0;
+  virtual void draw_pick(int &pickID, bool transformed = true) = 1;
 
   /** Assigns attributes of the selection based on the ID of the
    * object that was picked.  Can assume that pickID was one of
@@ -248,7 +248,7 @@ class Scene {
    * time this function is called.
    */
   void getHoveredObject(const Vector2D &p, bool getElement = true,
-                        bool transformed = false);
+                        bool transformed = true);
 
   /**
    * Returns true iff there is a hovered feature in the scene.


### PR DESCRIPTION
- Mouse move event fires too often on certain platforms, making the application unusable
    - `Application::render()` already takes care of updating the selection anyway
- `Scene::getHoveredObject()` now accounts for object transformation by default
    - This is more sensible, because it makes it much easier to manipulate objects that have already been transformed