### PR TITLE
slightly less undefined behavior in Vector3D and Vector4D implementation

### DIFF
--- a/CMU462/include/CMU462/vector3D.h
+++ b/CMU462/include/CMU462/vector3D.h
@@ -5,6 +5,7 @@
 
 #include <ostream>
 #include <cmath>
+#include <array>
 
 namespace CMU462 {
 
@@ -14,8 +15,14 @@ namespace CMU462 {
 class Vector3D {
  public:
 
-  // components
-  double x, y, z;
+  /**
+   * this type-punning is still technically undefined behavior, but all major
+   * compilers explicitly define it (gcc, clang, msvc)
+  */
+  union {
+    struct { double x; double y; double z; };
+    std::array<double, 3> data;
+  };
 
   /**
    * Constructor.
@@ -43,12 +50,12 @@ class Vector3D {
 
   // returns reference to the specified component (0-based indexing: x, y, z)
   inline double& operator[] ( const int& index ) {
-    return ( &x )[ index ];
+    return data[index];
   }
 
   // returns const reference to the specified component (0-based indexing: x, y, z)
   inline const double& operator[] ( const int& index ) const {
-    return ( &x )[ index ];
+    return data[index];
   }
 
   inline bool operator==( const Vector3D& v) const {

--- a/CMU462/include/CMU462/vector4D.h
+++ b/CMU462/include/CMU462/vector4D.h
@@ -15,8 +15,14 @@ namespace CMU462 {
 class Vector4D {
  public:
 
-  // components
-  double x, y, z, w;
+  /**
+   * this type-punning is still technically undefined behavior, but all major
+   * compilers explicitly define it (gcc, clang, msvc)
+  */
+  union {
+    struct { double x; double y; double z; double w; };
+    std::array<double, 4> data;
+  };
 
   /**
    * Constructor.
@@ -63,12 +69,12 @@ class Vector4D {
 
   // returns reference to the specified component (0-based indexing: x, y, z)
   inline double& operator[] ( const int& index ) {
-    return ( &x )[ index ];
+    return data[ index ];
   }
 
   // returns const reference to the specified component (0-based indexing: x, y, z)
   inline const double& operator[] ( const int& index ) const {
-    return ( &x )[ index ];
+    return data[ index ];
   }
 
   // negation


### PR DESCRIPTION
Vector3D and Vector4D depend on undefined (and brittle) behavior in their indexing overloads. This PR is still technically undefined behavior according to the C++ standard, but this form of type punning is defined and supported by all major C++ compilers (I know for a fact about gcc, clang, and mscv).